### PR TITLE
Harden CSS editor workflow boundaries

### DIFF
--- a/e2e/editor.spec.ts
+++ b/e2e/editor.spec.ts
@@ -175,7 +175,9 @@ test('reviews and imports live DevTools changes across CSS sections', async ({ p
   await expect(modal).not.toContainText('#resume');
   await modal.getByRole('button', { name: 'Import 2 changes' }).click();
 
-  await expect(page.getByRole('status')).toHaveText('Imported 2 live CSS changes.');
+  await expect(page.getByRole('status').filter({
+    hasText: /^Imported 2 live CSS changes\.$/,
+  })).toHaveText('Imported 2 live CSS changes.');
   await expect(syncBanner).not.toBeVisible();
 
   const imageHeading = page.locator('h2.css-title-heading').filter({

--- a/src/editor/__tests__/CssEditorArchitecture.test.ts
+++ b/src/editor/__tests__/CssEditorArchitecture.test.ts
@@ -1,0 +1,39 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const cssEditorDirectory = path.join(__dirname, "..", "CssEditor");
+const cssEditorSource = fs.readFileSync(path.join(cssEditorDirectory, "index.tsx"), "utf8");
+const resumeCssEditorSource = fs.readFileSync(
+    path.join(__dirname, "..", "..", "app", "ResumeCssEditor.tsx"),
+    "utf8"
+);
+
+test("the CSS editor composition does not own global inspection or live-sync policy", () => {
+    expect(cssEditorSource).not.toMatch(
+        /liveCssBaseline|inspectLiveCss|toastStore|editorStore|createContainer|react-dom/
+    );
+});
+
+test("recursive CSS editors receive one command surface", () => {
+    expect(cssEditorSource).not.toMatch(
+        /\b(addSelector|updateName|updateProperty|updateDescription|updateSelector|replaceProperties|deleteKey|deleteNode)=/
+    );
+    expect(cssEditorSource.match(/commands=\{props\.commands\}/g)).toHaveLength(3);
+});
+
+test("ResumeCssEditor remains a lifecycle and rendering adapter", () => {
+    expect(resumeCssEditorSource).not.toMatch(
+        /setInterval|clearInterval|inspectScopedLiveCssChanges|liveCssBaselineStore|applyScopedLiveCssChanges|changesSignature|useState|useCallback/
+    );
+    expect(resumeCssEditorSource).toContain("liveCssSyncCoordinator.connect()");
+});
+
+test("focused CSS view adapters remain present", () => {
+    expect(fs.readdirSync(cssEditorDirectory).sort()).toEqual([
+        "CssAncestorRules.tsx",
+        "CssHighlightPortal.tsx",
+        "CssPropertyEditor.tsx",
+        "CssRuleEditor.tsx",
+        "index.tsx"
+    ]);
+});

--- a/src/shared/stores/LiveCssSyncCoordinator.ts
+++ b/src/shared/stores/LiveCssSyncCoordinator.ts
@@ -103,9 +103,12 @@ export class LiveCssSyncCoordinator {
             if (!connected) return;
             connected = false;
             this.connectionCount--;
-            if (this.connectionCount === 0 && this.intervalHandle !== undefined) {
-                this.dependencies.scheduler.clearInterval(this.intervalHandle);
-                this.intervalHandle = undefined;
+            if (this.connectionCount === 0) {
+                if (this.intervalHandle !== undefined) {
+                    this.dependencies.scheduler.clearInterval(this.intervalHandle);
+                    this.intervalHandle = undefined;
+                }
+                this.setSnapshot(EMPTY_SNAPSHOT);
             }
         };
     }

--- a/src/shared/stores/__tests__/LiveCssSyncCoordinator.test.ts
+++ b/src/shared/stores/__tests__/LiveCssSyncCoordinator.test.ts
@@ -57,7 +57,7 @@ function createCoordinator(initialChanges: ScopedLiveCssTreeChange[] = []) {
 
 describe("LiveCssSyncCoordinator", () => {
     test("owns one polling lifecycle across connected views", () => {
-        const { coordinator, dependencies } = createCoordinator();
+        const { coordinator, dependencies, setChanges, refresh } = createCoordinator();
 
         const disconnectFirst = coordinator.connect();
         const disconnectSecond = coordinator.connect();
@@ -71,10 +71,18 @@ describe("LiveCssSyncCoordinator", () => {
 
         disconnectFirst();
         expect(dependencies.scheduler.clearInterval).not.toHaveBeenCalled();
+        setChanges([createChange()]);
+        refresh();
+        expect(coordinator.getSnapshot().changeCount).toBe(1);
         disconnectSecond();
         disconnectSecond();
         expect(dependencies.scheduler.clearInterval).toHaveBeenCalledWith("live-css-timer");
         expect(dependencies.scheduler.clearInterval).toHaveBeenCalledTimes(1);
+        expect(coordinator.getSnapshot()).toEqual({
+            changes: [],
+            changeCount: 0,
+            reviewOpen: false
+        });
     });
 
     test("reconciles equivalent scans without publishing duplicate state", () => {


### PR DESCRIPTION
## Outcome

Completes the follow-up hardening for the CSS editor workflow refactor tracked by vincentlaucsb/experiencer-pro#9.

- resets coordinator-owned live-CSS review state when the final view disconnects
- adds architecture guards that keep CssEditor and ResumeCssEditor thin adapters
- makes the affected Playwright toast assertion target the correct ARIA status region

## Verification

- 92 OSS source test suites / 566 tests
- OSS production build
- live DevTools CSS import Playwright journey
- independent implementation review and final branch review: no findings
- CSS-history editor and live-CSS modal scenes in light/dark: exact baseline matches