### PR TITLE
Add asynchronous document opening extension

### DIFF
--- a/src/app/Resume.tsx
+++ b/src/app/Resume.tsx
@@ -30,6 +30,8 @@ export type {
     ResumeAppExtensions,
     ResumeDocumentAction,
     ResumeDocumentGroup,
+    ResumeDocumentOpeningExtensions,
+    ResumeDocumentOpeningRenderProps,
     ResumeEditorExtensions,
     ResumeLandingExtensions,
     ResumeProps,
@@ -43,7 +45,11 @@ export function Resume(props: ResumeProps) {
     const extensions = resolveResumeAppExtensions(props);
     const pageSize = props.pageSize || PageSize.Letter;
     const nodes = props.tree.childNodes || [];
-    const isEditing = (props.mode || 'landing') === 'normal';
+    const documentOpen = props.documentOpen?.status === 'loading'
+        || props.documentOpen?.status === 'error'
+        ? props.documentOpen
+        : undefined;
+    const isEditing = !documentOpen && (props.mode || 'landing') === 'normal';
     const shell = (
         <ResumeShell
             isEditing={isEditing}
@@ -59,10 +65,21 @@ export function Resume(props: ResumeProps) {
             renameDocument={props.renameDocument}
             importDocument={props.importDocument}
             saveStatus={props.saveStatus}
+            landingNavigationDisabled={Boolean(documentOpen)}
             additionalToolbarSections={extensions.editor?.additionalToolbarSections}
             extensions={extensions.shell}
         />
     );
+
+    if (documentOpen) {
+        const opening = extensions.documentOpening?.render?.({
+            topNav: shell,
+            state: documentOpen,
+            retry: props.retryDocumentOpen,
+            dismiss: props.dismissDocumentOpen
+        });
+        return <>{opening ?? shell}</>;
+    }
 
     switch (props.mode) {
         case 'changingTemplate':

--- a/src/app/ResumeAppContainer.tsx
+++ b/src/app/ResumeAppContainer.tsx
@@ -13,13 +13,15 @@ import { useTreeStylesheet } from '@/shared/stores/cssStoreHooks';
 import { useDocumentFonts } from '@/shared/stores/documentFontsStore';
 import useStylesheet from '@/shared/hooks/useStylesheet';
 import type { ResumeDocumentSummary } from '@/shared/repositories/ResumeRepository';
-import ResumeLibraryStore from '@/shared/stores/resumeLibraryStore';
+import ResumeLibraryStore, {
+    type ResumeLibraryController
+} from '@/shared/stores/resumeLibraryStore';
 
 /**
  * Subscribes to application stores and projects snapshots into the composition view.
  */
 export default function ResumeAppContainer(props: ResumeWrapperProps) {
-    const libraryStore = React.useMemo(
+    const libraryStore = React.useMemo<ResumeLibraryController>(
         () => props.resumeLibraryStore ?? new ResumeLibraryStore(props.resumeRepository),
         [props.resumeLibraryStore, props.resumeRepository]
     );
@@ -126,6 +128,9 @@ export default function ResumeAppContainer(props: ResumeWrapperProps) {
                 createDocumentFromTemplate={libraryStore.createDocumentFromTemplate}
                 importDocument={libraryStore.importDocument}
                 saveStatus={library.saveStatus}
+                documentOpen={library.documentOpen}
+                retryDocumentOpen={libraryStore.retryDocumentOpen}
+                dismissDocumentOpen={libraryStore.dismissDocumentOpen}
                 extensions={extensions}
             />
         </>

--- a/src/app/ResumeAppContracts.ts
+++ b/src/app/ResumeAppContracts.ts
@@ -7,7 +7,10 @@ import type { ToolbarData } from '@/controls/toolbar/ToolbarMaker';
 import type { LandingActions, LandingContext } from '@/help/Landing';
 import type { ResumeDocumentSummary, ResumeRepository } from '@/shared/repositories/ResumeRepository';
 import type { ResumeAppExtensionsStore } from '@/shared/stores/resumeAppExtensionsStore';
-import type { ResumeLibraryController } from '@/shared/stores/resumeLibraryStore';
+import type {
+    ResumeDocumentOpenSnapshot,
+    ResumeLibraryController
+} from '@/shared/stores/resumeLibraryStore';
 import type { ResumeDocumentSource } from '@/shared/resumeDocument/prepareResumeDocument';
 import type { EditorMode, ResumeFont, ResumeNode } from '@/types';
 import PageSize from '@/types/PageSize';
@@ -57,6 +60,17 @@ export interface ResumeEditorExtensions {
     additionalSidebarTabs?: AdditionalSidebarTab[];
 }
 
+export interface ResumeDocumentOpeningRenderProps {
+    topNav: React.ReactNode;
+    state: Exclude<ResumeDocumentOpenSnapshot, { status: 'idle' }>;
+    retry?: () => void;
+    dismiss?: () => void;
+}
+
+export interface ResumeDocumentOpeningExtensions {
+    render?: (props: ResumeDocumentOpeningRenderProps) => React.ReactNode;
+}
+
 export interface ResumeLandingExtensions {
     renderLandingLead?: (actions: LandingActions, context: LandingContext) => React.ReactNode;
     landingClassName?: string;
@@ -73,6 +87,7 @@ export interface ResumeTemplateExtensions {
 export interface ResumeAppExtensions {
     shell?: ResumeShellExtensions;
     editor?: ResumeEditorExtensions;
+    documentOpening?: ResumeDocumentOpeningExtensions;
     landing?: ResumeLandingExtensions;
     templates?: ResumeTemplateExtensions;
 }
@@ -105,6 +120,7 @@ export interface ResumeProps {
     hasSuspendedSession?: boolean;
     lastDocumentId?: string;
     saveStatus?: string;
+    documentOpen?: ResumeDocumentOpenSnapshot;
     proBadge?: string;
     accountLabel?: string;
     editingStorage?: 'local' | 'cloud';
@@ -118,6 +134,8 @@ export interface ResumeProps {
     renameDocument?: (id: string, title: string) => Promise<string | null>;
     createDocumentFromTemplate?: (key?: string) => Promise<void> | void;
     importDocument?: (data: object, title?: string) => void;
+    retryDocumentOpen?: () => void;
+    dismissDocumentOpen?: () => void;
     fileMenuItems?: MenuItem[];
     helpMenuItems?: MenuItem[];
     topSecondaryItems?: React.ReactNode;
@@ -139,6 +157,7 @@ export function mergeResumeAppExtensions(
     return {
         shell: { ...base.shell, ...override.shell },
         editor: { ...base.editor, ...override.editor },
+        documentOpening: { ...base.documentOpening, ...override.documentOpening },
         landing: { ...base.landing, ...override.landing },
         templates: { ...base.templates, ...override.templates }
     };
@@ -167,6 +186,7 @@ export function resolveResumeAppExtensions(props: ResumeWrapperProps | ResumePro
             additionalSidebarTabs: props.extensions?.editor?.additionalSidebarTabs
                 ?? props.additionalSidebarTabs
         },
+        documentOpening: props.extensions?.documentOpening,
         landing: {
             renderLandingLead: props.extensions?.landing?.renderLandingLead ?? props.renderLandingLead,
             landingClassName: props.extensions?.landing?.landingClassName ?? props.landingClassName,

--- a/src/app/ResumeShell.tsx
+++ b/src/app/ResumeShell.tsx
@@ -32,6 +32,7 @@ export interface ResumeShellProps {
     renameDocument?: (id: string, title: string) => Promise<string | null>;
     importDocument?: (data: object, title?: string) => void;
     saveStatus?: string;
+    landingNavigationDisabled?: boolean;
     additionalToolbarSections?: ToolbarData;
     extensions?: ResumeShellExtensions;
     coordinator?: ResumeAppCoordinator;
@@ -73,6 +74,7 @@ export default function ResumeShell(props: ResumeShellProps) {
                 exportToPng={() => output.exportPng(source)}
                 print={() => output.print(source)}
                 new={() => coordinator.showTemplateSelector()}
+                landingNavigationDisabled={props.landingNavigationDisabled}
                 documents={props.documents}
                 documentLabels={props.documentLabels}
                 activeDocumentId={props.activeDocumentId}

--- a/src/app/__tests__/Resume.tsx
+++ b/src/app/__tests__/Resume.tsx
@@ -52,6 +52,81 @@ function renderTemplateSwitcher(createDocumentFromTemplate = jest.fn()) {
     );
 }
 
+test('renders an inert editor-shaped surface while a document opens', () => {
+    const dismiss = jest.fn();
+    render(
+        <ResumeView
+            mode="landing"
+            stylesheet=""
+            tree={{ type: "Resume", uuid: "test-root", childNodes: [] }}
+            documentOpen={{
+                status: 'loading',
+                documentId: 'cloud:resume-1',
+                title: 'Platform Resume'
+            }}
+            dismissDocumentOpen={dismiss}
+            extensions={{
+                documentOpening: {
+                    render: ({ topNav, state }) => (
+                        <div className="host-document-opening">
+                            {topNav}
+                            <div role="status" aria-live="polite">
+                                <h2>Opening {state.title}…</h2>
+                            </div>
+                        </div>
+                    )
+                }
+            }}
+        />
+    );
+
+    expect(screen.getByRole('status').getAttribute('aria-live')).toBe('polite');
+    expect(screen.getByRole('heading', { name: 'Opening Platform Resume…' })).toBeTruthy();
+    expect(document.querySelector('.host-document-opening')).not.toBeNull();
+    expect(document.querySelector('#resume')).toBeNull();
+    const home = screen.getByRole('button', { name: 'Go to landing page' });
+    expect(home.getAttribute('aria-disabled')).toBe('true');
+    fireEvent.click(home);
+    expect(dismiss).not.toHaveBeenCalled();
+});
+
+test('offers retry and back actions after a document open fails', () => {
+    const retry = jest.fn();
+    const dismiss = jest.fn();
+    render(
+        <ResumeView
+            mode="landing"
+            stylesheet=""
+            tree={{ type: "Resume", uuid: "test-root", childNodes: [] }}
+            documentOpen={{
+                status: 'error',
+                documentId: 'cloud:resume-1',
+                title: 'Platform Resume',
+                message: 'The cloud request failed.'
+            }}
+            retryDocumentOpen={retry}
+            dismissDocumentOpen={dismiss}
+            extensions={{
+                documentOpening: {
+                    render: ({ state, retry: retryOpen, dismiss: dismissOpen }) => (
+                        <div role="alert">
+                            <p>{state.message}</p>
+                            <button onClick={retryOpen}>Try again</button>
+                            <button onClick={dismissOpen}>Back</button>
+                        </div>
+                    )
+                }
+            }}
+        />
+    );
+
+    expect(screen.getByRole('alert').textContent).toContain('The cloud request failed.');
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+    expect(retry).toHaveBeenCalledTimes(1);
+    expect(dismiss).toHaveBeenCalledTimes(1);
+});
+
 function createRepository(document: ResumeDocument): jest.Mocked<ResumeRepository> {
     let documents: ResumeDocumentSummary[] = [{
         id: document.id,

--- a/src/app/__tests__/ResumeAppContracts.test.ts
+++ b/src/app/__tests__/ResumeAppContracts.test.ts
@@ -28,6 +28,7 @@ test('merges hosted extension groups under caller overrides', () => {
     )).toEqual({
         shell: { accountLabel: 'Override', proBadge: 'Pro' },
         editor: {},
+        documentOpening: {},
         landing: {},
         templates: {}
     });

--- a/src/controls/TopNavBar/TopNavBar.scss
+++ b/src/controls/TopNavBar/TopNavBar.scss
@@ -117,6 +117,10 @@ header#app-header {
         flex: 0 0 auto;
         cursor: pointer;
 
+        &[aria-disabled="true"] {
+            cursor: default;
+        }
+
         &:focus-visible {
             border-radius: 4px;
             outline: 3px solid colors.$focus-ring;

--- a/src/controls/TopNavBar/index.tsx
+++ b/src/controls/TopNavBar/index.tsx
@@ -50,6 +50,7 @@ export function TopNavBar(props: TopNavBarProps) {
     ]);
 
     const onBrandKeyDown = (event: React.KeyboardEvent<HTMLHeadingElement>) => {
+        if (props.landingNavigationDisabled) return;
         if (event.key === "Enter" || event.key === " ") {
             event.preventDefault();
             props.toggleLanding();
@@ -66,11 +67,12 @@ export function TopNavBar(props: TopNavBarProps) {
             <div className="brand-primary">
                 <h1
                     aria-label="Go to landing page"
+                    aria-disabled={props.landingNavigationDisabled || undefined}
                     className="app-m-3"
-                    onClick={props.toggleLanding}
+                    onClick={props.landingNavigationDisabled ? undefined : props.toggleLanding}
                     onKeyDown={onBrandKeyDown}
                     role="button"
-                    tabIndex={0}
+                    tabIndex={props.landingNavigationDisabled ? -1 : 0}
                 >
                     <img
                         className="brand-mark"

--- a/src/controls/TopNavBar/types.ts
+++ b/src/controls/TopNavBar/types.ts
@@ -36,6 +36,7 @@ export interface TopNavBarProps {
     /** Workspace navigation. */
     new: Action;
     toggleLanding: Action;
+    landingNavigationDisabled?: boolean;
 }
 
 export type TopNavBarWrapperProps = Omit<

--- a/src/shared/stores/resumeLibraryStore.ts
+++ b/src/shared/stores/resumeLibraryStore.ts
@@ -19,7 +19,17 @@ export interface ResumeLibrarySnapshot {
     documents: ResumeDocumentSummary[];
     activeDocumentId?: string;
     saveStatus: string;
+    documentOpen?: ResumeDocumentOpenSnapshot;
 }
+
+export type ResumeDocumentOpenSnapshot =
+    | { status: "idle" }
+    | {
+        status: "loading" | "error";
+        documentId: string;
+        title: string;
+        message?: string;
+    };
 
 export interface ResumeLibraryController {
     subscribe(listener: () => void): () => void;
@@ -34,6 +44,8 @@ export interface ResumeLibraryController {
     renameDocument(id: string, title: string): Promise<string | null>;
     applyExternalDocument(document: ResumeDocument, saveStatus?: string): Promise<void>;
     refreshCurrentDocument(): Promise<ResumeDocumentSummary | undefined>;
+    retryDocumentOpen?(): Promise<void>;
+    dismissDocumentOpen?(): void;
 }
 
 const initialSnapshot: ResumeLibrarySnapshot = {


### PR DESCRIPTION
## Outcome

Adds a generic asynchronous document-opening surface so consuming applications can render their shell immediately while a document is loading or has failed to load.

## Design

- Adds framework-neutral opening state and retry/dismiss commands to the resume library contract.
- Routes opening presentation through an optional extension renderer; OSS remains Pro-agnostic and falls back safely to the shell.
- Disables landing navigation while an opening request owns the surface.

## Verification

- Focused Jest suites: 41 tests passed, including Resume architecture and extension contracts.
- `npm run build` passed.
- Independent post-rebase review found no P0, P1, P2, or integration findings.