### PR TITLE
Make icon subset check newline-safe

### DIFF
--- a/scripts/generate-icofont-subset.mjs
+++ b/scripts/generate-icofont-subset.mjs
@@ -183,10 +183,16 @@ async function assertCurrent(expected, outputPath) {
     } catch {
         throw new Error(`${path.relative(repositoryRoot, outputPath)} is missing; run npm run icons:generate.`);
     }
-    const expectedBuffer = Buffer.isBuffer(expected) ? expected : Buffer.from(expected);
-    if (!actual.equals(expectedBuffer)) {
+    const isCurrent = Buffer.isBuffer(expected)
+        ? actual.equals(expected)
+        : normalizeNewlines(actual.toString("utf8")) === normalizeNewlines(expected);
+    if (!isCurrent) {
         throw new Error(`${path.relative(repositoryRoot, outputPath)} is stale; run npm run icons:generate.`);
     }
+}
+
+function normalizeNewlines(value) {
+    return value.replace(/\r\n?/g, "\n");
 }
 
 const generated = await generateSubset();


### PR DESCRIPTION
## Summary
- normalize generated icon CSS line endings during freshness checks
- preserve byte-exact verification for the generated font binary
- keep `npm run build` reliable on Windows checkouts using CRLF

## Verification
- `npm run icons:check`
- `npm run build`
- `git diff --check`

Follow-up to #64 after an independent review found the Windows-only build failure.