### PR TITLE
Support landing document action feedback

### DIFF
--- a/src/app/ResumeLanding.tsx
+++ b/src/app/ResumeLanding.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/shared/services/ResumeAppCoordinator';
 import type { ResumeDocumentSummary } from '@/shared/repositories/ResumeRepository';
 import loadData from '@/shared/stores/loadData';
+import Toast from '@/controls/Toast';
 
 export interface ResumeLandingProps {
     topNav: React.ReactNode;
@@ -47,23 +48,26 @@ export default function ResumeLanding(props: ResumeLandingProps) {
     return (
         <DefaultLayout
             topNav={props.topNav}
-            main={<Landing
-                className={props.className}
-                loadLocal={() => { void resumeFromLanding(); }}
-                new={createResume}
-                loadData={props.importDocument ?? importLocalData}
-                hasLocalResume={props.hasSuspendedSession || Boolean(props.lastDocumentId)}
-                documents={props.documents}
-                documentLabels={props.documentLabels}
-                documentGroups={props.documentGroups}
-                documentActions={props.documentActions}
-                activeDocumentId={props.activeDocumentId}
-                openDocument={props.selectDocument}
-                deleteDocument={props.deleteDocument}
-                renameDocument={props.renameDocument}
-                renderLead={props.renderLead}
-                showSocialLinks={props.showSocialLinks}
-            />}
+            main={<>
+                <Landing
+                    className={props.className}
+                    loadLocal={() => { void resumeFromLanding(); }}
+                    new={createResume}
+                    loadData={props.importDocument ?? importLocalData}
+                    hasLocalResume={props.hasSuspendedSession || Boolean(props.lastDocumentId)}
+                    documents={props.documents}
+                    documentLabels={props.documentLabels}
+                    documentGroups={props.documentGroups}
+                    documentActions={props.documentActions}
+                    activeDocumentId={props.activeDocumentId}
+                    openDocument={props.selectDocument}
+                    deleteDocument={props.deleteDocument}
+                    renameDocument={props.renameDocument}
+                    renderLead={props.renderLead}
+                    showSocialLinks={props.showSocialLinks}
+                />
+                <Toast />
+            </>}
         />
     );
 }

--- a/src/help/Landing.tsx
+++ b/src/help/Landing.tsx
@@ -183,13 +183,6 @@ export default function Landing(props: LandingProps) {
                                             setEditingDocumentId(document.id);
                                             setEditingTitle(document.title);
                                         }}>Rename</Button>
-                                        <Button
-                                            appearance="outline"
-                                            variant="error"
-                                            onClick={() => props.deleteDocument?.(document.id)}
-                                        >
-                                            Delete
-                                        </Button>
                                         {props.documentActions?.[document.id]?.map((action) => (
                                             <Button
                                                 disabled={action.disabled}
@@ -199,6 +192,13 @@ export default function Landing(props: LandingProps) {
                                                 {action.label}
                                             </Button>
                                         ))}
+                                        <Button
+                                            appearance="outline"
+                                            variant="error"
+                                            onClick={() => props.deleteDocument?.(document.id)}
+                                        >
+                                            Delete
+                                        </Button>
                                     </div>
                                 </article>
                             ))}


### PR DESCRIPTION
## Summary
- render product-provided document actions before the destructive Delete action
- mount the shared accessible toast on the landing surface so asynchronous actions can report success or failure

## Verification
- npm test -- --runInBand ResumeLanding Landing.test
- independent review: no findings

This OSS change remains product-agnostic and only improves generic landing extension behavior.