### PR TITLE
Consolidate document library actions

### DIFF
--- a/src/app/Resume.tsx
+++ b/src/app/Resume.tsx
@@ -97,7 +97,9 @@ export function Resume(props: ResumeProps) {
                     topNav={shell}
                     className={extensions.landing?.landingClassName}
                     documents={props.documents}
+                    documentLibraryLead={extensions.landing?.documentLibraryLead}
                     documentLabels={extensions.landing?.documentLabels}
+                    documentMetadata={extensions.landing?.documentMetadata}
                     documentGroups={extensions.landing?.documentGroups}
                     documentActions={extensions.landing?.documentActions}
                     activeDocumentId={props.activeDocumentId}

--- a/src/app/ResumeAppContracts.ts
+++ b/src/app/ResumeAppContracts.ts
@@ -75,7 +75,9 @@ export interface ResumeLandingExtensions {
     renderLandingLead?: (actions: LandingActions, context: LandingContext) => React.ReactNode;
     landingClassName?: string;
     showLandingSocialLinks?: boolean;
+    documentLibraryLead?: React.ReactNode;
     documentLabels?: Record<string, string>;
+    documentMetadata?: Record<string, string>;
     documentGroups?: ResumeDocumentGroup[];
     documentActions?: Record<string, ResumeDocumentAction[]>;
 }
@@ -192,7 +194,9 @@ export function resolveResumeAppExtensions(props: ResumeWrapperProps | ResumePro
             landingClassName: props.extensions?.landing?.landingClassName ?? props.landingClassName,
             showLandingSocialLinks: props.extensions?.landing?.showLandingSocialLinks
                 ?? props.showLandingSocialLinks,
+            documentLibraryLead: props.extensions?.landing?.documentLibraryLead,
             documentLabels: props.extensions?.landing?.documentLabels ?? props.documentLabels,
+            documentMetadata: props.extensions?.landing?.documentMetadata,
             documentGroups: props.extensions?.landing?.documentGroups ?? props.documentGroups,
             documentActions: props.extensions?.landing?.documentActions ?? props.documentActions
         },

--- a/src/app/ResumeLanding.tsx
+++ b/src/app/ResumeLanding.tsx
@@ -15,7 +15,9 @@ export interface ResumeLandingProps {
     topNav: React.ReactNode;
     className?: string;
     documents?: ResumeDocumentSummary[];
+    documentLibraryLead?: React.ReactNode;
     documentLabels?: Record<string, string>;
+    documentMetadata?: Record<string, string>;
     documentGroups?: ResumeDocumentGroup[];
     documentActions?: Record<string, ResumeDocumentAction[]>;
     activeDocumentId?: string;
@@ -56,7 +58,9 @@ export default function ResumeLanding(props: ResumeLandingProps) {
                     loadData={props.importDocument ?? importLocalData}
                     hasLocalResume={props.hasSuspendedSession || Boolean(props.lastDocumentId)}
                     documents={props.documents}
+                    documentLibraryLead={props.documentLibraryLead}
                     documentLabels={props.documentLabels}
+                    documentMetadata={props.documentMetadata}
                     documentGroups={props.documentGroups}
                     documentActions={props.documentActions}
                     activeDocumentId={props.activeDocumentId}

--- a/src/app/__tests__/ResumeLanding.test.tsx
+++ b/src/app/__tests__/ResumeLanding.test.tsx
@@ -135,6 +135,8 @@ test('keeps document groups and actions generic for embedding products', () => {
         <ResumeLanding
             topNav={<header />}
             createResume={jest.fn()}
+            documentLibraryLead={<p>Reusable documents appear first.</p>}
+            documentMetadata={{ 'cloud:1': 'Last used Never' }}
             documentActions={{
                 'local:1': [{
                     id: 'copy',
@@ -167,6 +169,9 @@ test('keeps document groups and actions generic for embedding products', () => {
 
     expect(screen.getByRole('heading', { name: 'Cloud resumes' })).toBeTruthy();
     expect(screen.getByRole('heading', { name: 'On this device' })).toBeTruthy();
-    fireEvent.click(screen.getByRole('button', { name: 'Copy to cloud' }));
+    expect(screen.getByText('Reusable documents appear first.')).toBeTruthy();
+    expect(screen.getByText('Last used Never')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'More Actions for Local Resume' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Copy to cloud' }));
     expect(copy).toHaveBeenCalledTimes(1);
 });

--- a/src/help/Landing.tsx
+++ b/src/help/Landing.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import PureMenu, { PureMenuItem } from "@/controls/menus/PureMenu";
+import { DropdownMenu, type MenuItem as DropdownMenuItem } from "@/controls/menus/poprightMenu";
 import FileLoader from "@/controls/FileLoader";
 import Modal from "@/controls/Modal";
 import { Globals, Action } from "@/types";
@@ -20,7 +21,9 @@ interface LandingProps {
     new: () => void;
     hasLocalResume?: boolean;
     documents?: ResumeDocumentSummary[];
+    documentLibraryLead?: React.ReactNode;
     documentLabels?: Record<string, string>;
+    documentMetadata?: Record<string, string>;
     documentGroups?: ResumeDocumentGroup[];
     documentActions?: Record<string, ResumeDocumentAction[]>;
     activeDocumentId?: string;
@@ -40,6 +43,53 @@ export interface LandingActions {
 export interface LandingContext {
     documentCount: number;
     hasResumableSession: boolean;
+}
+
+function DocumentActionsMenu(props: {
+    document: ResumeDocumentSummary;
+    actions?: ResumeDocumentAction[];
+    onRename?: () => void;
+}) {
+    const [open, setOpen] = React.useState(false);
+    const menuId = `document-actions-${React.useId().replace(/:/g, "")}`;
+    const items: DropdownMenuItem[] = [
+        ...(props.onRename ? [{
+            id: `rename-${props.document.id}`,
+            label: "Rename",
+            onSelect: props.onRename
+        }] : []),
+        ...(props.actions ?? []).map((action) => ({
+            id: `${action.id}-${props.document.id}`,
+            label: action.label,
+            disabled: action.disabled,
+            onSelect: () => void action.run()
+        }))
+    ];
+
+    if (!items.length) return null;
+
+    return (
+        <DropdownMenu
+            className="resume-library-actions-menu"
+            id={menuId}
+            items={items}
+            side="bottom"
+            align="end"
+            minWidth={190}
+            onOpen={() => setOpen(true)}
+            onClose={() => setOpen(false)}
+        >
+            <Button
+                aria-label={`More Actions for ${props.document.title}`}
+                aria-controls={menuId}
+                aria-expanded={open}
+                aria-haspopup="menu"
+            >
+                <span aria-hidden="true">⋯</span>
+                <span>More Actions</span>
+            </Button>
+        </DropdownMenu>
+    );
 }
 
 function MenuItem (props: {
@@ -104,6 +154,7 @@ export default function Landing(props: LandingProps) {
                 </>}
                 {props.documents?.length || groups.some((group) => group.showWhenEmpty) ? (
                     <section className="resume-library" aria-label="Resume library">
+                        {props.documentLibraryLead}
                         {groups.map((group) => {
                             const documents = group.documentIds
                                 .map((id) => documentsById.get(id))
@@ -170,6 +221,9 @@ export default function Landing(props: LandingProps) {
                                                     : <></>}
                                             </h3>
                                             <p>Version {document.version} · Updated {browserDateTimeFormatter.formatDateTime(document.updatedAt)}</p>
+                                            {props.documentMetadata?.[document.id]
+                                                ? <p className="resume-library-metadata">{props.documentMetadata[document.id]}</p>
+                                                : <></>}
                                         </div>
                                     )}
                                     <div className="resume-library-actions">
@@ -179,19 +233,14 @@ export default function Landing(props: LandingProps) {
                                         >
                                             Open
                                         </Button>
-                                        <Button onClick={() => {
-                                            setEditingDocumentId(document.id);
-                                            setEditingTitle(document.title);
-                                        }}>Rename</Button>
-                                        {props.documentActions?.[document.id]?.map((action) => (
-                                            <Button
-                                                disabled={action.disabled}
-                                                key={action.id}
-                                                onClick={() => void action.run()}
-                                            >
-                                                {action.label}
-                                            </Button>
-                                        ))}
+                                        <DocumentActionsMenu
+                                            document={document}
+                                            actions={props.documentActions?.[document.id]}
+                                            onRename={props.renameDocument ? () => {
+                                                setEditingDocumentId(document.id);
+                                                setEditingTitle(document.title);
+                                            } : undefined}
+                                        />
                                         <Button
                                             appearance="outline"
                                             variant="error"

--- a/src/help/__tests__/Landing.test.tsx
+++ b/src/help/__tests__/Landing.test.tsx
@@ -110,7 +110,10 @@ test("renders grouped documents and invokes origin-specific secondary actions", 
             .classList.contains("pure-button-outline")
     ).toBe(true);
 
-    fireEvent.click(within(localGroup).getByRole("button", { name: "Copy to cloud" }));
+    fireEvent.click(within(localGroup).getByRole("button", {
+        name: "More Actions for Local Resume"
+    }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Copy to cloud" }));
     expect(copy).toHaveBeenCalledTimes(1);
 });
 
@@ -132,7 +135,8 @@ test("keeps rename open and shows the action message when saving fails", async (
         />
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Rename" }));
+    fireEvent.click(screen.getByRole("button", { name: "More Actions for Original" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Rename" }));
     const name = screen.getByRole("textbox", { name: "Name" });
     expect(name.getAttribute("maxlength")).toBe("200");
     fireEvent.change(name, { target: { value: "Rejected name" } });
@@ -142,6 +146,28 @@ test("keeps rename open and shows the action message when saving fails", async (
         .toBe("Name must be 200 characters or fewer.");
     expect(screen.getByRole("textbox", { name: "Name" })).toBeTruthy();
     expect(rename).toHaveBeenCalledWith("resume-1", "Rejected name");
+});
+
+test("renders a library lead and document-specific metadata", () => {
+    render(
+        <Landing
+            documentLibraryLead={<aside>Create reusable starting points.</aside>}
+            documentMetadata={{ "resume-1": "Last used Never" }}
+            documents={[{
+                id: "resume-1",
+                title: "Template",
+                schemaVersion: 1,
+                version: 1,
+                updatedAt: "2026-07-28T00:00:00Z"
+            }]}
+            loadData={jest.fn()}
+            loadLocal={jest.fn()}
+            new={jest.fn()}
+        />
+    );
+
+    expect(screen.getByText("Create reusable starting points.")).toBeTruthy();
+    expect(screen.getByText("Last used Never")).toBeTruthy();
 });
 
 test("shows understated metadata for an empty document group", () => {

--- a/src/sass/landing.scss
+++ b/src/sass/landing.scss
@@ -159,8 +159,21 @@
 }
 
 .resume-library-actions {
+    align-items: center;
     display: flex;
+    flex-wrap: wrap;
     gap: 0.5rem;
+
+    .pure-button {
+        align-items: center;
+        display: inline-flex;
+        gap: 0.35rem;
+        white-space: nowrap;
+    }
+}
+
+.resume-library-item .resume-library-metadata {
+    color: colors.$text-secondary;
 }
 
 .resume-library-edit {


### PR DESCRIPTION
## Summary
- replace per-row Rename/Duplicate buttons with an accessible More Actions menu
- preserve Open and outlined Delete as direct actions
- add generic landing extension points for library guidance and document metadata

## Verification
- npm test -- --runInBand --testPathIgnorePatterns=e2e (96 suites, 586 tests)
- npm run build
- focused landing tests (10 tests)
- independent final review: no findings