### PR TITLE
Show live template previews as paper documents

### DIFF
--- a/src/app/ResumeTemplateSelector.tsx
+++ b/src/app/ResumeTemplateSelector.tsx
@@ -202,13 +202,16 @@ export default function ResumeTemplateSelector(props: ResumeTemplateSelectorProp
         );
     } else if (snapshot.preview.status === 'ready' && snapshot.preview.data) {
         preview = (
-            <ResumePreviewFrame
-                data={snapshot.preview.data}
-                pageSize={props.pageSize}
-                ariaLabel={`${additionalTemplate.title} template preview`}
-                target="isolated-preview"
-                iframeClassName="template-preview-frame"
-            />
+            <div className="template-preview-paper">
+                <ResumePreviewFrame
+                    data={snapshot.preview.data}
+                    pageSize={snapshot.preview.data.pageSize ?? props.pageSize}
+                    ariaLabel={`${additionalTemplate.title} template preview`}
+                    target="isolated-preview"
+                    iframeClassName="template-preview-frame"
+                    fitDocument
+                />
+            </div>
         );
     } else {
         preview = (

--- a/src/resume/ResumePreview.tsx
+++ b/src/resume/ResumePreview.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/shared/resumeDocument/prepareResumeDocument';
 import type { ResumeSaveData } from '@/types';
 import PageSize from '@/types/PageSize';
+import { fitPreviewFrameToDocument } from '@/shared/utils/fitPreviewFrameToDocument';
 
 const noopUpdate = () => undefined;
 
@@ -28,6 +29,7 @@ export interface ResumePreviewFrameProps extends BaseResumePreviewProps {
     iframeTitle?: string;
     iframeClassName?: string;
     iframeRef?: React.Ref<HTMLIFrameElement>;
+    fitDocument?: boolean;
 }
 
 export interface StandaloneResumePreviewProps extends BaseResumePreviewProps {
@@ -75,6 +77,9 @@ export function ResumePreviewFrame(props: ResumePreviewFrameProps) {
             removeHead();
         };
     }, [frameDocument, prepared]);
+
+    React.useLayoutEffect(() => fitPreviewFrameToDocument(frameDocument, props.fitDocument),
+        [frameDocument, props.fitDocument, prepared]);
 
     const contents = frameDocument && createPortal(
         <ReadOnlyResumeDocument prepared={prepared} />,

--- a/src/sass/template-selector.scss
+++ b/src/sass/template-selector.scss
@@ -79,12 +79,21 @@
 
 .template-preview-frame {
     display: block;
-    width: 100%;
-    min-width: 100%;
-    height: 100%;
+    flex: 0 0 auto;
     min-height: 14rem;
     border: 0;
-    background: colors.$surface-workspace;
+    background: white;
+    box-shadow: 0 0.25rem 1rem rgb(0 0 0 / 18%);
+}
+
+.template-preview-paper {
+    display: flex;
+    width: max-content;
+    min-width: 100%;
+    box-sizing: border-box;
+    justify-content: center;
+    padding: 1rem;
+    background: colors.$surface-muted;
 }
 
 .template-preview-image {

--- a/src/shared/utils/__tests__/fitPreviewFrameToDocument.test.ts
+++ b/src/shared/utils/__tests__/fitPreviewFrameToDocument.test.ts
@@ -1,0 +1,46 @@
+import { fitPreviewFrameToDocument } from '../fitPreviewFrameToDocument';
+
+test('fits an opted-in frame and restores its dimensions on teardown', () => {
+    const frame = document.createElement('iframe');
+    frame.style.width = '100%';
+    frame.style.height = '400px';
+    document.body.append(frame);
+    const body = frame.contentDocument!.body;
+    // JSDOM has no layout engine; dimensions and resize notifications are browser boundaries.
+    let height = 1056;
+    jest.spyOn(body, 'getBoundingClientRect').mockImplementation(() => ({
+        width: 816, height, top: 0
+    } as DOMRect));
+    let notify = () => {};
+    const disconnect = jest.fn();
+    const previousObserver = global.ResizeObserver;
+    global.ResizeObserver = jest.fn(callback => {
+        notify = () => callback([], {} as ResizeObserver);
+        return { observe: jest.fn(), disconnect, unobserve: jest.fn() };
+    });
+    try {
+        expect(fitPreviewFrameToDocument(frame.contentDocument)).toBeUndefined();
+        expect(frame.style.width).toBe('100%');
+        const cleanup = fitPreviewFrameToDocument(frame.contentDocument, true)!;
+        expect(frame.style.width).toBe('816px');
+        expect(frame.style.height).toBe('1056px');
+        height = 2200.5;
+        notify();
+        expect(frame.style.height).toBe('2201px');
+        height = 1056;
+        notify();
+        expect(frame.style.height).toBe('1056px');
+        jest.spyOn(frame.contentDocument!.documentElement, 'getBoundingClientRect')
+            .mockReturnValue({ height: 1088 } as DOMRect);
+        notify();
+        expect(frame.style.height).toBe('1088px');
+        cleanup();
+        expect(disconnect).toHaveBeenCalledTimes(1);
+        expect(frame.style.width).toBe('100%');
+        expect(frame.style.height).toBe('400px');
+    } finally {
+        global.ResizeObserver = previousObserver;
+        frame.remove();
+        jest.restoreAllMocks();
+    }
+});

--- a/src/shared/utils/fitPreviewFrameToDocument.ts
+++ b/src/shared/utils/fitPreviewFrameToDocument.ts
@@ -1,0 +1,28 @@
+/** Sizes an opt-in preview's outer frame without adding application styles to its document. */
+export function fitPreviewFrameToDocument(target: Document | null, enabled = false): (() => void) | undefined {
+    const frame = target?.defaultView?.frameElement as HTMLIFrameElement | null;
+    if (!enabled || !target || !frame) return;
+    const previousWidth = frame.style.width;
+    const previousHeight = frame.style.height;
+    const measure = () => {
+        const body = target.body;
+        const bounds = body.getBoundingClientRect();
+        frame.style.width = `${bounds.width}px`;
+        // Root bounds include margins that collapse outside the body on unstyled documents.
+        // scrollHeight on the root is viewport-sized and would prevent a preview from shrinking.
+        frame.style.height = `${Math.ceil(Math.max(
+            target.documentElement.getBoundingClientRect().height,
+            bounds.top + bounds.height,
+            bounds.top + body.scrollHeight
+        ))}px`;
+    };
+    const observer = new ResizeObserver(measure);
+    observer.observe(target.body);
+    observer.observe(target.documentElement);
+    measure();
+    return () => {
+        observer.disconnect();
+        frame.style.width = previousWidth;
+        frame.style.height = previousHeight;
+    };
+}


### PR DESCRIPTION
Live template previews filled the picker panel with a white iframe, hiding the paper boundary. Center them on the same muted canvas and shadow used by image previews, preserve saved Letter/A4 dimensions, and fit the frame to document content including collapsed margins.

The reusable frame-sizing adapter is opt-in and leaves authored styles and other rendering surfaces isolated. Verified with 137 focused OSS tests, the OSS build, and Pro Playwright coverage for light/dark framing, narrow screens, long A4 content, and switching back to Letter. Independent review found no actionable issues.