### PR TITLE
Add free stylesheet themes to the template picker

### DIFF
--- a/docs/RESUME-DOCUMENT-PIPELINE.md
+++ b/docs/RESUME-DOCUMENT-PIPELINE.md
@@ -100,3 +100,21 @@ Changes to this pipeline require focused unit/contract tests and browser coverag
 - target teardown removes temporary roots, frames, and installed head resources.
 
 When a defect is visible only in an iframe, popup, export, screenshot, or dedicated route, a state-only unit test is not sufficient. Add a test at the failing browser boundary.
+
+## Template themes
+
+Built-in theme catalogs own names, swatch fills, and pure stylesheet transforms. The shared
+`applyTemplateTheme` service gives each transform fresh root and built-in CSS trees from the
+selected template's default document. Transforms may change either tree; palette helpers
+are conveniences, not a restriction to color substitution.
+
+The template selector owns the current theme only while choosing a template. It previews the
+transformed document through `ResumePreviewFrame` and passes that same document into the
+creation port. Persisted documents contain the resulting CSS, never a theme identifier.
+Subsequent catalog changes cannot restyle existing documents. Changing themes always starts
+from the default document; it never layers transforms or infers a theme from arbitrary CSS.
+
+Additional catalogs may supply their own transforms through the generic selector option.
+Creation remains owned by that option's command. Options without themes retain their existing
+preview and creation behavior. Swatches support any CSS background fill, including split colors,
+and use named native radio controls so selection does not depend on perceiving color.

--- a/e2e/editor.spec.ts
+++ b/e2e/editor.spec.ts
@@ -242,9 +242,11 @@ test('template preview does not inherit the active resume stylesheet', async ({ 
   await page.getByRole('menuitem', { name: 'New', exact: true }).click();
   await page.getByText('Integrity', { exact: true }).click();
 
-  const preview = page.getByRole('img', { name: 'Integrity template preview' });
+  const preview = page.getByTitle('Integrity template preview');
   await expect(preview).toBeVisible();
-  await expect(preview).toHaveAttribute('src', /integrity/i);
+  await expect(page.frameLocator('.template-preview-frame').locator('body'))
+    .toHaveCSS('--secondary-color', '#fbdcb6');
+  await expect(page.frameLocator('.template-preview-frame').locator('#resume')).toHaveCount(0);
   await expect(page.locator('style[data-resume-editor-stylesheet]')).toHaveText('');
 });
 

--- a/src/app/ResumeAppContracts.ts
+++ b/src/app/ResumeAppContracts.ts
@@ -12,7 +12,7 @@ import type {
     ResumeLibraryController
 } from '@/shared/stores/resumeLibraryStore';
 import type { ResumeDocumentSource } from '@/shared/resumeDocument/prepareResumeDocument';
-import type { EditorMode, ResumeFont, ResumeNode } from '@/types';
+import type { EditorMode, ResumeFont, ResumeNode, ResumeSaveData } from '@/types';
 import PageSize from '@/types/PageSize';
 
 export type { AdditionalSidebarTab } from '@/app/ResumeEditor';
@@ -134,7 +134,7 @@ export interface ResumeProps {
     deleteDocument?: (id: string) => void;
     requestDeleteConfirmation?: DeleteDocumentConfirmationRequest;
     renameDocument?: (id: string, title: string) => Promise<string | null>;
-    createDocumentFromTemplate?: (key?: string) => Promise<void> | void;
+    createDocumentFromTemplate?: (key?: string, data?: ResumeSaveData) => Promise<void> | void;
     importDocument?: (data: object, title?: string) => void;
     retryDocumentOpen?: () => void;
     dismissDocumentOpen?: () => void;

--- a/src/app/ResumeTemplateSelector.tsx
+++ b/src/app/ResumeTemplateSelector.tsx
@@ -1,3 +1,5 @@
+import { TemplateThemeSelector } from './TemplateThemeSelector';
+import type { TemplateTheme } from '@/shared/templates/templateTheme';
 import * as React from 'react';
 
 import { Button } from '@/controls/Buttons';
@@ -22,7 +24,8 @@ export interface AdditionalTemplateOption {
     previewImage?: string;
     previewAlt?: string;
     previewLabel?: string;
-    use: () => Promise<void> | void;
+    themes?: readonly TemplateTheme[];
+    use: (data?: ResumeSaveData) => Promise<void> | void;
     useLabel?: string;
     useDescription?: React.ReactNode;
 }
@@ -38,7 +41,7 @@ export interface ResumeTemplateSelectorProps {
     topNav: React.ReactNode;
     pageSize: PageSize;
     additionalTemplateGroups?: AdditionalTemplateGroup[];
-    createDocumentFromTemplate?: (key?: string) => Promise<void> | void;
+    createDocumentFromTemplate?: (key?: string, data?: ResumeSaveData) => Promise<void> | void;
     store?: TemplateSelectorController;
 }
 
@@ -179,7 +182,7 @@ export default function ResumeTemplateSelector(props: ResumeTemplateSelectorProp
     );
 
     let preview: React.ReactNode;
-    if (!additionalTemplate) {
+    if (!additionalTemplate && !snapshot.preview.data) {
         preview = <BuiltInTemplatePreview templateKey={snapshot.selectedBuiltInKey} />;
     } else if (snapshot.preview.status === 'error') {
         preview = (
@@ -191,12 +194,12 @@ export default function ResumeTemplateSelector(props: ResumeTemplateSelectorProp
         preview = (
             <div className="template-preview-image">
                 <div className="template-preview-label">
-                    {additionalTemplate.previewLabel ?? 'Preview only'}
+                    {additionalTemplate?.previewLabel ?? 'Preview only'}
                 </div>
                 <img
                     src={snapshot.preview.image}
-                    alt={additionalTemplate.previewAlt
-                        ?? `${additionalTemplate.title} template preview`}
+                    alt={additionalTemplate?.previewAlt
+                        ?? `${additionalTemplate?.title ?? snapshot.selectedBuiltInKey} template preview`}
                 />
             </div>
         );
@@ -206,7 +209,7 @@ export default function ResumeTemplateSelector(props: ResumeTemplateSelectorProp
                 <ResumePreviewFrame
                     data={snapshot.preview.data}
                     pageSize={snapshot.preview.data.pageSize ?? props.pageSize}
-                    ariaLabel={`${additionalTemplate.title} template preview`}
+                    ariaLabel={`${additionalTemplate?.title ?? snapshot.selectedBuiltInKey} template preview`}
                     target="isolated-preview"
                     iframeClassName="template-preview-frame"
                     fitDocument
@@ -224,7 +227,12 @@ export default function ResumeTemplateSelector(props: ResumeTemplateSelectorProp
     return (
         <StaticSidebarLayout
             topNav={props.topNav}
-            main={preview}
+            main={snapshot.themes?.length ? <div className="template-themed-preview">
+                {preview}
+                <TemplateThemeSelector themes={snapshot.themes ?? []} selectedId={snapshot.selectedThemeId}
+                    disabled={snapshot.actionStatus === 'using' || snapshot.preview.status !== 'ready'}
+                    select={store.selectTheme} />
+            </div> : preview}
             sidebar={sidebar}
         />
     );

--- a/src/app/TemplateThemeSelector.tsx
+++ b/src/app/TemplateThemeSelector.tsx
@@ -1,0 +1,27 @@
+import type { TemplateTheme } from '@/shared/templates/templateTheme';
+
+/** Native radio controls provide keyboard selection and expose names independently of color. */
+export function TemplateThemeSelector(props: {
+    themes: readonly TemplateTheme[];
+    selectedId?: string;
+    disabled: boolean;
+    select(id: string): void;
+}) {
+    if (!props.themes.length) return null;
+    const selected = props.themes.find(theme => theme.id === props.selectedId);
+    return (
+        <fieldset className="template-theme-selector" disabled={props.disabled}>
+            <legend>Theme{selected ? ` · ${selected.name}` : ''}</legend>
+            <div className="template-theme-swatches">
+                {props.themes.map(theme => (
+                    <label key={theme.id} className="template-theme-option" title={theme.name}>
+                        <input type="radio" name="template-theme" value={theme.id}
+                            aria-label={theme.name} checked={theme.id === props.selectedId}
+                            onChange={() => props.select(theme.id)} />
+                        <span className="template-theme-fill" style={{ background: theme.fill }} aria-hidden="true" />
+                    </label>
+                ))}
+            </div>
+        </fieldset>
+    );
+}

--- a/src/app/__tests__/Resume.tsx
+++ b/src/app/__tests__/Resume.tsx
@@ -301,7 +301,7 @@ test('Template switcher previews the selected template', async () => {
     const view = renderTemplateSwitcher();
     const integrityOption = screen.getByText('Integrity').closest('.pure-menu-item');
 
-    await waitFor(() => expect(screen.getByAltText('Integrity template preview')).toBeTruthy());
+    await waitFor(() => expect(screen.getByTitle('Integrity template preview')).toBeTruthy());
     expect(document.getElementById('resume-document-builtin-fonts')).toBeNull();
     expect(integrityOption?.classList.contains('pure-menu-selected')).toBe(true);
 
@@ -309,7 +309,7 @@ test('Template switcher previews the selected template', async () => {
         fireEvent.click(screen.getByText('Assured'));
     });
 
-    expect(screen.getByAltText('Assured template preview')).toBeTruthy();
+    expect(screen.getByTitle('Assured template preview')).toBeTruthy();
     expect(screen.queryByText('Randy Marsh')).toBeNull();
     expect(screen.getByText('Assured').closest('.pure-menu-item')
         ?.classList.contains('pure-menu-selected')).toBe(true);
@@ -469,12 +469,12 @@ test('Template switcher suspends and restores the active resume stylesheet', asy
     await waitFor(() => expect(editorStyle?.textContent).toContain("background: #e8e8e8"));
 });
 
-test('Template switcher uses a generated screenshot for built-in template previews', () => {
+test('Template switcher uses an isolated live document for themed template previews', () => {
     const view = renderTemplateSwitcher();
-    const preview = screen.getByAltText('Integrity template preview');
+    const preview = screen.getByTitle('Integrity template preview');
 
-    expect(preview.getAttribute('src')).toBe('/template-previews/integrity.png');
-    expect(view.container.querySelector('.template-preview-frame')).toBeNull();
+    expect(preview.tagName).toBe('IFRAME');
+    expect(screen.getByRole('radio', { name: 'Original' }).getAttribute('checked')).not.toBeNull();
     expect(view.container.querySelector('#resume')).toBeNull();
 });
 

--- a/src/sass/template-selector.scss
+++ b/src/sass/template-selector.scss
@@ -1,4 +1,5 @@
 @use "colors/semantic" as colors;
+@use "variables";
 
 #template-selector {
     .pure-menu-link,
@@ -130,4 +131,83 @@
     /* Keep generated Letter-page previews centered in the available picker canvas. */
     align-self: center;
     box-shadow: 0 0.25rem 1rem rgb(0 0 0 / 18%);
+}
+
+.template-themed-preview {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+
+    > .template-preview-paper,
+    > .template-preview-image {
+        flex: 1;
+        min-height: 0;
+        overflow: auto;
+        width: auto;
+        justify-content: flex-start;
+    }
+
+    > .template-preview-paper {
+        align-items: flex-start;
+        justify-content: safe center;
+    }
+}
+
+.template-theme-selector {
+    flex: 0 0 auto;
+    margin: 0;
+    padding: 0.65rem 1rem 0.85rem;
+    border: 0;
+    background: colors.$surface-muted;
+    color: colors.$text-primary;
+
+    legend { float: left; margin-right: 1rem; line-height: 2.75rem; }
+}
+
+.template-theme-swatches { display: flex; flex-wrap: wrap; gap: 0.25rem; }
+
+.template-theme-option {
+    position: relative;
+    display: grid;
+    width: 2.75rem;
+    height: 2.75rem;
+    place-items: center;
+    cursor: pointer;
+
+    input {
+        position: absolute;
+        inset: 0;
+        margin: 0;
+        opacity: 0;
+        cursor: pointer;
+    }
+
+    .template-theme-fill {
+        width: 1.35rem;
+        height: 1.35rem;
+        border-radius: 50%;
+        border: 1px solid colors.$border-strong;
+        pointer-events: none;
+    }
+
+    input:checked + .template-theme-fill {
+        outline: 2px solid colors.$text-primary;
+        outline-offset: 3px;
+    }
+
+    input:focus-visible + .template-theme-fill {
+        outline: 3px solid colors.$focus-ring;
+        outline-offset: 4px;
+    }
+
+    input:disabled { cursor: wait; }
+}
+
+// Give the stacked preview its own space so the template list cannot cover the swatches.
+@media (max-width: variables.$screen-small) {
+    #main-grid:has(.template-themed-preview) > :first-child {
+        flex: 0 0 60vh;
+        min-height: 20rem;
+    }
 }

--- a/src/shared/stores/__tests__/templateSelectorStore.test.ts
+++ b/src/shared/stores/__tests__/templateSelectorStore.test.ts
@@ -161,7 +161,7 @@ test('returns to the built-in selection when an additional template disappears',
 
     expect(store.getSnapshot()).toMatchObject({
         selectedBuiltInKey: 'Integrity',
-        preview: { status: 'idle' },
+        preview: { status: 'ready' },
         actionError: 'This template is no longer available.'
     });
     expect(store.getSnapshot().selectedAdditionalKey).toBeUndefined();

--- a/src/shared/stores/resumeLibraryStore.ts
+++ b/src/shared/stores/resumeLibraryStore.ts
@@ -39,7 +39,7 @@ export interface ResumeLibraryController {
     selectDocument(id: string): Promise<void>;
     hasUnsavedChanges(): boolean;
     saveCurrentDocument(): Promise<ResumeDocument | undefined>;
-    createDocumentFromTemplate(key?: string): Promise<void>;
+    createDocumentFromTemplate(key?: string, data?: ResumeSaveData): Promise<void>;
     importDocument(data: object, title?: string): Promise<void>;
     deleteDocument(id: string): Promise<void>;
     renameDocument(id: string, title: string): Promise<string | null>;
@@ -144,11 +144,11 @@ export default class ResumeLibraryStore implements ResumeLibraryController {
         }
     };
 
-    createDocumentFromTemplate = async (key = "Integrity") => {
+    createDocumentFromTemplate = async (key = "Integrity", data?: ResumeSaveData) => {
         this.setSnapshot({ saveStatus: "Creating" });
 
         try {
-            const template: ResumeSaveData = ResumeTemplates.templates[key];
+            const template: ResumeSaveData = data ?? ResumeTemplates.templates[key];
             const document = await this.repository.create({
                 title: key,
                 schemaVersion: 1,

--- a/src/shared/stores/templateSelectorStore.ts
+++ b/src/shared/stores/templateSelectorStore.ts
@@ -1,3 +1,5 @@
+import { builtinTemplateThemes } from '@/templates/builtinTemplateThemes';
+import { applyTemplateTheme, type TemplateTheme } from '@/shared/templates/templateTheme';
 import loadData from '@/shared/stores/loadData';
 import ResumeTemplates from '@/templates/ResumeTemplates';
 import type { ResumeSaveData } from '@/types';
@@ -13,6 +15,8 @@ export interface TemplatePreviewSnapshot {
 }
 
 export interface TemplateSelectorSnapshot {
+    selectedThemeId?: string;
+    themes?: readonly TemplateTheme[];
     selectedBuiltInKey: string;
     selectedAdditionalKey?: string;
     preview: TemplatePreviewSnapshot;
@@ -24,7 +28,8 @@ export interface TemplateSelectorOption {
     id: string;
     loadPreview?: () => Promise<ResumeSaveData>;
     previewImage?: string;
-    use: () => Promise<void> | void;
+    themes?: readonly TemplateTheme[];
+    use: (data?: ResumeSaveData) => Promise<void> | void;
 }
 
 export interface TemplateSelectorGroupConfiguration {
@@ -34,7 +39,7 @@ export interface TemplateSelectorGroupConfiguration {
 
 export interface TemplateSelectorConfiguration {
     groups: readonly TemplateSelectorGroupConfiguration[];
-    useBuiltInTemplate?: (key: string) => Promise<void> | void;
+    useBuiltInTemplate?: (key: string, data?: ResumeSaveData) => Promise<void> | void;
 }
 
 export interface TemplateSelectorController {
@@ -43,6 +48,7 @@ export interface TemplateSelectorController {
     configure(configuration: TemplateSelectorConfiguration): void;
     selectBuiltIn(key: string): void;
     selectAdditional(groupId: string, templateId: string): void;
+    selectTheme(id: string): void;
     useSelected(): Promise<void>;
 }
 
@@ -66,21 +72,33 @@ function actionErrorMessage(error: unknown): string {
         : 'Could not create a document from this template.';
 }
 
+function builtInPreview(key: string): Pick<TemplateSelectorSnapshot, 'preview' | 'themes' | 'selectedThemeId'> {
+    const themes = builtinTemplateThemes[key];
+    return {
+        themes,
+        selectedThemeId: themes?.[0]?.id,
+        preview: themes?.length
+            ? { status: 'ready', data: applyTemplateTheme(ResumeTemplates.templates[key], themes[0]) }
+            : idlePreview
+    };
+}
+
 /** Owns template selection and asynchronous template workflows independently of React. */
 export class TemplateSelectorStore implements TemplateSelectorController {
     private snapshot: TemplateSelectorSnapshot = {
         selectedBuiltInKey: 'Integrity',
-        preview: idlePreview,
+        ...builtInPreview('Integrity'),
         actionStatus: 'idle'
     };
     private readonly listeners = new Set<() => void>();
     private options = new Map<string, TemplateSelectorOption>();
-    private useBuiltInTemplate: (key: string) => Promise<void> | void;
+    private useBuiltInTemplate: (key: string, data?: ResumeSaveData) => Promise<void> | void;
+    private defaultPreview?: ResumeSaveData;
     private previewRequestId = 0;
     private actionRequestId = 0;
 
     constructor(
-        private readonly fallbackUseBuiltInTemplate: (key: string) => Promise<void> | void
+        private readonly fallbackUseBuiltInTemplate: (key: string, data?: ResumeSaveData) => Promise<void> | void
     ) {
         this.useBuiltInTemplate = fallbackUseBuiltInTemplate;
     }
@@ -115,7 +133,7 @@ export class TemplateSelectorStore implements TemplateSelectorController {
             this.setSnapshot({
                 ...this.snapshot,
                 selectedAdditionalKey: undefined,
-                preview: idlePreview,
+                ...builtInPreview(this.snapshot.selectedBuiltInKey),
                 actionStatus: 'idle',
                 actionError: unavailableMessage
             });
@@ -123,7 +141,7 @@ export class TemplateSelectorStore implements TemplateSelectorController {
         }
 
         if (selectedOption !== previousOption) {
-            this.loadPreview(selectedKey, selectedOption);
+            this.loadPreview(selectedKey, selectedOption, true);
         }
     };
 
@@ -131,7 +149,7 @@ export class TemplateSelectorStore implements TemplateSelectorController {
         this.invalidateRequests();
         this.setSnapshot({
             selectedBuiltInKey: key,
-            preview: idlePreview,
+            ...builtInPreview(key),
             actionStatus: 'idle'
         });
     };
@@ -145,7 +163,7 @@ export class TemplateSelectorStore implements TemplateSelectorController {
             this.setSnapshot({
                 ...this.snapshot,
                 selectedAdditionalKey: undefined,
-                preview: idlePreview,
+                ...builtInPreview(this.snapshot.selectedBuiltInKey),
                 actionStatus: 'idle',
                 actionError: unavailableMessage
             });
@@ -166,11 +184,15 @@ export class TemplateSelectorStore implements TemplateSelectorController {
         }
 
         const requestId = ++this.actionRequestId;
-        const command = option?.use
-            ?? (() => this.useBuiltInTemplate(this.snapshot.selectedBuiltInKey));
+        // Only theme-capable options receive local preview data. Remote templates retain their server-owned creation path.
+        const data = this.snapshot.themes?.length ? this.snapshot.preview.data : undefined;
+        const command = option
+            ? () => data ? option.use(data) : option.use()
+            : () => data ? this.useBuiltInTemplate(this.snapshot.selectedBuiltInKey, data)
+                : this.useBuiltInTemplate(this.snapshot.selectedBuiltInKey);
         this.setSnapshot({
             ...this.snapshot,
-            actionStatus: option ? 'using' : 'idle',
+            actionStatus: 'using',
             actionError: undefined
         });
 
@@ -192,22 +214,44 @@ export class TemplateSelectorStore implements TemplateSelectorController {
         }
     };
 
+    selectTheme = (id: string): void => {
+        if (this.snapshot.actionStatus === 'using' || this.snapshot.preview.status !== 'ready') return;
+        const theme = this.snapshot.themes?.find(candidate => candidate.id === id);
+        const data = this.snapshot.selectedAdditionalKey
+            ? this.defaultPreview : ResumeTemplates.templates[this.snapshot.selectedBuiltInKey];
+        if (!theme || !data) return;
+        try {
+            const themed = applyTemplateTheme(data, theme);
+            this.setSnapshot({ ...this.snapshot, selectedThemeId: id,
+                preview: { status: 'ready', data: themed }, actionError: undefined });
+        } catch (error: unknown) {
+            this.setSnapshot({ ...this.snapshot, actionError: actionErrorMessage(error) });
+        }
+    };
+
     reset = (): void => {
         this.invalidateRequests();
         this.options = new Map();
         this.useBuiltInTemplate = this.fallbackUseBuiltInTemplate;
         this.setSnapshot({
             selectedBuiltInKey: 'Integrity',
-            preview: idlePreview,
+            ...builtInPreview('Integrity'),
             actionStatus: 'idle'
         });
     };
 
-    private loadPreview(key: string, option: TemplateSelectorOption): void {
+    private loadPreview(key: string, option: TemplateSelectorOption, preserveTheme = false): void {
         const requestId = ++this.previewRequestId;
         ++this.actionRequestId;
 
-        if (option.previewImage) {
+        this.defaultPreview = undefined;
+        // Projection updates may replace option objects while the same template stays selected.
+        // Keep the palette when still available; explicit template selection starts at Original.
+        const theme = (preserveTheme
+            ? option.themes?.find(candidate => candidate.id === this.snapshot.selectedThemeId)
+            : undefined) ?? option.themes?.[0];
+        this.snapshot = { ...this.snapshot, themes: option.themes, selectedThemeId: theme?.id };
+        if (option.previewImage && !option.themes?.length) {
             this.setSnapshot({
                 ...this.snapshot,
                 selectedAdditionalKey: key,
@@ -251,9 +295,10 @@ export class TemplateSelectorStore implements TemplateSelectorController {
         void preview
             .then((data) => {
                 if (!this.isCurrentPreview(requestId, key)) return;
+                this.defaultPreview = data;
                 this.setSnapshot({
                     ...this.snapshot,
-                    preview: { status: 'ready', data }
+                    preview: { status: 'ready', data: theme ? applyTemplateTheme(data, theme) : data }
                 });
             })
             .catch((error: unknown) => this.finishPreviewError(requestId, key, error));
@@ -286,8 +331,8 @@ export class TemplateSelectorStore implements TemplateSelectorController {
     }
 }
 
-const useDefaultBuiltInTemplate = (key: string): void => {
-    loadData(ResumeTemplates.templates[key], 'changingTemplate');
+const useDefaultBuiltInTemplate = (key: string, data?: ResumeSaveData): void => {
+    loadData(data ?? ResumeTemplates.templates[key], 'changingTemplate');
 };
 
 export const templateSelectorStore = new TemplateSelectorStore(useDefaultBuiltInTemplate);

--- a/src/shared/templates/templateTheme.ts
+++ b/src/shared/templates/templateTheme.ts
@@ -1,0 +1,36 @@
+import CssNode from '@/shared/CssTree';
+import { deepCopy } from '@/shared/utils/deepCopy';
+import type { ResumeSaveData } from '@/types';
+
+export interface TemplateCss {
+    rootCss: CssNode;
+    builtinCss: CssNode;
+}
+
+export type TemplateThemeTransform = (defaultCss: TemplateCss) => TemplateCss;
+
+/** Catalog-only presentation metadata; documents persist just the transformed CSS. */
+export interface TemplateTheme {
+    id: string;
+    name: string;
+    fill: string;
+    transform: TemplateThemeTransform;
+}
+
+/** Always starts from an isolated copy of the default, never a previous theme result. */
+export function applyTemplateTheme(defaultDocument: ResumeSaveData, theme: TemplateTheme): ResumeSaveData {
+    const document = deepCopy(defaultDocument);
+    const css = theme.transform({
+        rootCss: CssNode.load(document.rootCss),
+        builtinCss: CssNode.load(document.builtinCss)
+    });
+    return { ...document, rootCss: css.rootCss.dump(), builtinCss: css.builtinCss.dump() };
+}
+
+/** A convenience transform for palettes; themes may also restructure either CSS tree. */
+export function rootPalette(properties: Record<string, string>): TemplateThemeTransform {
+    return css => {
+        css.rootCss.setProperties(current => new Map([...current, ...Object.entries(properties)]));
+        return css;
+    };
+}

--- a/src/templates/__tests__/builtinTemplateThemes.test.ts
+++ b/src/templates/__tests__/builtinTemplateThemes.test.ts
@@ -1,0 +1,67 @@
+import CssNode from '@/shared/CssTree';
+import { applyTemplateTheme } from '@/shared/templates/templateTheme';
+import { builtinTemplateThemes } from '../builtinTemplateThemes';
+import ResumeTemplates from '../ResumeTemplates';
+import { TemplateSelectorStore } from '@/shared/stores/templateSelectorStore';
+
+test.each(Object.entries(builtinTemplateThemes))('%s palettes preserve content and default CSS', (name, themes) => {
+    const original = ResumeTemplates.templates[name];
+    const before = JSON.stringify(original);
+    for (const theme of themes) {
+        const result = applyTemplateTheme(original, theme);
+        expect(result.childNodes).toEqual(original.childNodes);
+        expect(Object.keys(result)).toEqual(Object.keys(original));
+        expect(CssNode.load(result.rootCss).stylesheet()).not.toContain('#resume');
+        expect(result).toEqual(applyTemplateTheme(original, theme));
+    }
+    expect(JSON.stringify(original)).toBe(before);
+    expect(applyTemplateTheme(original, themes[0])).toEqual(original);
+});
+
+test('switching themes starts from defaults and creation receives only document data', async () => {
+    let created;
+    const store = new TemplateSelectorStore((_key, data) => { created = data; });
+    store.selectBuiltIn('Integrity');
+    store.selectTheme('plum');
+    store.selectTheme('ocean');
+    const expected = applyTemplateTheme(ResumeTemplates.templates.Integrity, builtinTemplateThemes.Integrity[1]);
+    expect(store.getSnapshot().preview.data).toEqual(expected);
+    await store.useSelected();
+    expect(created).toEqual(expected);
+    store.selectTheme('original');
+    expect(store.getSnapshot().preview.data).toEqual(ResumeTemplates.templates.Integrity);
+});
+
+test('a transform can change selectors and declarations in both CSS trees', () => {
+    const result = applyTemplateTheme(ResumeTemplates.templates.Assured, {
+        id: 'arbitrary', name: 'Arbitrary', fill: 'linear-gradient(red, blue)',
+        transform: css => {
+            css.builtinCss.addNode('Theme rule', { 'letter-spacing': '0.01em' }, '.entry');
+            css.rootCss.addNode('Print rule', { color: 'black' }, 'body');
+            return css;
+        }
+    });
+    expect(CssNode.load(result.builtinCss).stylesheet()).toContain('letter-spacing: 0.01em');
+    expect(CssNode.load(result.rootCss).stylesheet()).toContain('color: black');
+});
+
+
+test('a refreshed option preserves the selected palette and uses the refreshed default document', async () => {
+    const store = new TemplateSelectorStore(() => undefined);
+    const configure = (data: typeof ResumeTemplates.templates.Integrity) => store.configure({ groups: [{
+        id: 'extra', templates: [{ id: 'styled', themes: builtinTemplateThemes.Integrity,
+            loadPreview: async () => data, use: () => undefined }]
+    }] });
+    configure(ResumeTemplates.templates.Integrity);
+    store.selectAdditional('extra', 'styled');
+    await Promise.resolve();
+    store.selectTheme('plum');
+    const refreshed = { ...ResumeTemplates.templates.Integrity, childNodes: [] };
+    configure(refreshed);
+    await Promise.resolve();
+    expect(store.getSnapshot().selectedThemeId).toBe('plum');
+    expect(store.getSnapshot().preview.data).toEqual(applyTemplateTheme(refreshed, builtinTemplateThemes.Integrity[3]));
+    store.selectAdditional('extra', 'styled');
+    await Promise.resolve();
+    expect(store.getSnapshot().selectedThemeId).toBe('original');
+});

--- a/src/templates/builtinTemplateThemes.ts
+++ b/src/templates/builtinTemplateThemes.ts
@@ -1,0 +1,35 @@
+import { rootPalette, type TemplateTheme, type TemplateThemeTransform } from '@/shared/templates/templateTheme';
+
+/** Carries Assured's palette into the shared header, including cover letters without sections. */
+function assuredPalette(accent: string, background: string): TemplateThemeTransform {
+    return css => {
+        rootPalette({ '--accent': accent })(css);
+        css.builtinCss.mustFindNode('Header').setProperties(current =>
+            new Map([...current, ['background', background]]));
+        return css;
+    };
+}
+
+const assured: readonly TemplateTheme[] = [
+    { id: 'original', name: 'Original', fill: '#315eaa', transform: css => css },
+    { id: 'forest', name: 'Forest', fill: '#28634e', transform: assuredPalette('#28634e', '#e4eee8') },
+    { id: 'plum', name: 'Plum', fill: '#704367', transform: assuredPalette('#704367', '#efe5ed') },
+    { id: 'copper', name: 'Copper', fill: '#8b4d2e', transform: assuredPalette('#8b4d2e', '#f3e7de') }
+];
+
+const integrity: readonly TemplateTheme[] = [
+    { id: 'original', name: 'Original', fill: 'linear-gradient(135deg, #4eb3b9 50%, #fbdcb6 50%)', transform: css => css },
+    { id: 'ocean', name: 'Ocean', fill: 'linear-gradient(135deg, #639bc8 50%, #dcebf5 50%)',
+        transform: rootPalette({ '--randy-teal': '#639bc8', '--secondary-color': '#dcebf5', '--text-color': '#25394b' }) },
+    { id: 'forest', name: 'Forest', fill: 'linear-gradient(135deg, #76a58a 50%, #e4ebd6 50%)',
+        transform: rootPalette({ '--randy-teal': '#76a58a', '--secondary-color': '#e4ebd6', '--text-color': '#2b4033' }) },
+    { id: 'plum', name: 'Plum', fill: 'linear-gradient(135deg, #b58bab 50%, #f0dfeb 50%)',
+        transform: rootPalette({ '--randy-teal': '#b58bab', '--secondary-color': '#f0dfeb', '--text-color': '#493448' }) }
+];
+
+export const builtinTemplateThemes: Readonly<Record<string, readonly TemplateTheme[]>> = {
+    Assured: assured,
+    'Assured: Cover Letter': assured,
+    Integrity: integrity,
+    'Integrity: Cover Letter': integrity
+};


### PR DESCRIPTION
Adds free, template-specific stylesheet themes for Assured and Integrity, including matching cover letters. Named, keyboard-accessible swatches support multi-color fills and update an isolated live preview. Creation saves the transformed CSS without theme metadata.

Transforms receive fresh copies of both default CSS trees. Selection survives refreshed template options; additional catalogs can supply their own transforms through the existing extension boundary.

Validation: 98 OSS unit suites (594 tests), production build, 12 editor browser cases, and independent review with no outstanding findings. The Pro companion supplies Commander/Operator themes and Windows document/UI baselines for every palette.
